### PR TITLE
Correção da validação da tag nrRecibo

### DIFF
--- a/src/Factories/EvtServPrest.php
+++ b/src/Factories/EvtServPrest.php
@@ -62,7 +62,7 @@ class EvtServPrest extends Factory implements FactoryInterface
             $ideEvento,
             "nrRecibo",
             !empty($this->std->nrrecibo) ? $this->std->nrrecibo : null,
-            true
+            $this->std->indretif == 2 ? true : false
         );
         $this->dom->addChild(
             $ideEvento,


### PR DESCRIPTION
Aplicado um if para deixar obrigatório a tag nrRecibo apenas quando indRetif == 2