### PR TITLE
Erro no validador multipleOf

### DIFF
--- a/jsonSchemes/v2_01_02/evtTomadorServicos.schema
+++ b/jsonSchemes/v2_01_02/evtTomadorServicos.schema
@@ -47,8 +47,7 @@
         },
         "vlrtotalbruto": {
             "required": true,
-            "type": "number",
-            "multipleOf": 0.01
+            "type": "number"
         },
         "vlrtotalbaseret": {
            "required": true,


### PR DESCRIPTION
Para o valor 571123.7 acusa erro 'JSON does not validate. Violations: [vlrtotalbruto] Must be a multiple of 0.01'.

Validando o calculo feito pela class https://github.com/justinrainbow/json-schema/blob/master/src/JsonSchema/Constraints/NumberConstraint.php#L64C93-L64C93 o valor retornado para 571123.7 é
-1.1641532182693E-10

![image](https://github.com/nfephp-org/sped-efdreinf/assets/12185147/171f48ba-79b0-414d-9e2b-e32ac11e8f93)
