### PR TITLE
Ajustes no evento R-1070

### DIFF
--- a/src/Factories/EvtTabProcesso.php
+++ b/src/Factories/EvtTabProcesso.php
@@ -110,9 +110,6 @@ class EvtTabProcesso extends Factory implements FactoryInterface
             );
         } elseif ($this->std->modo == 'ALT') {
             //alteracao
-            if (empty($this->std->fimvalid)) {
-                throw new \Exception("Numa alteração é obrigatório informar o FIM da VALIDADE do evento anterior.");
-            }
             $node = $this->dom->createElement("alteracao");
             $this->dom->addChild(
                 $ideProcesso,

--- a/src/Factories/EvtTabProcesso.php
+++ b/src/Factories/EvtTabProcesso.php
@@ -99,7 +99,7 @@ class EvtTabProcesso extends Factory implements FactoryInterface
             $this->dom->addChild(
                 $ideProcesso,
                 "fimValid",
-                null,
+                !empty($this->std->fimvalid) ? $this->std->fimvalid : null,
                 false
             );
             $this->dom->addChild(


### PR DESCRIPTION
Ajusta o R-1070 para cobrir os seguintes pontos:

- Permitir a inclusão do fim da validade, já que é permitido no layout. 
- Não deve obrigatoriamente preencher o fim de validade (fimValid) ao alterar o evento R-1070, pois início e fim de validade são chaves do registro e serão utilizadas para busca na alteração do evento.